### PR TITLE
Updated Hamcrest version to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
 
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/hamcrest/MapUtil.java
+++ b/src/main/java/org/apache/sling/hamcrest/MapUtil.java
@@ -45,10 +45,10 @@ final class MapUtil {
         }
         if (args.length == 1) {
             if (args[0] instanceof Map) {
-                return (Map)args[0];
+                return (Map<String, Object>)args[0];
             }
             else if (args[0] instanceof Dictionary) {
-                return toMap((Dictionary)args[0]);
+                return toMap((Dictionary<String, Object>)args[0]);
             }
         }
         if (args.length % 2 != 0) {

--- a/src/main/java/org/apache/sling/hamcrest/MapUtil.java
+++ b/src/main/java/org/apache/sling/hamcrest/MapUtil.java
@@ -20,7 +20,6 @@ package org.apache.sling.hamcrest;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,13 +42,8 @@ final class MapUtil {
         if (args == null || args.length == 0) {
             return Collections.emptyMap();
         }
-        if (args.length == 1) {
-            if (args[0] instanceof Map) {
-                return (Map<String, Object>)args[0];
-            }
-            else if (args[0] instanceof Dictionary) {
-                return toMap((Dictionary<String, Object>)args[0]);
-            }
+        if (args.length == 1 && args[0] instanceof Map) {
+            return (Map<String, Object>)args[0];
         }
         if (args.length % 2 != 0) {
             throw new IllegalArgumentException("args must be an even number of name/values:" + Arrays.asList(args));

--- a/src/main/java/org/apache/sling/hamcrest/ResourceCollectionMatchers.java
+++ b/src/main/java/org/apache/sling/hamcrest/ResourceCollectionMatchers.java
@@ -24,7 +24,7 @@ import org.apache.sling.hamcrest.matchers.ResourceCollectionPathMatcher;
 import org.hamcrest.Matcher;
 
 /**
- * A collection of <tt>Matcher</tt>s for resource collections.
+ * A collection of {@code Matcher}s for resource collections.
  */
 public final class ResourceCollectionMatchers {
     

--- a/src/main/java/org/apache/sling/hamcrest/ResourceIteratorMatchers.java
+++ b/src/main/java/org/apache/sling/hamcrest/ResourceIteratorMatchers.java
@@ -24,7 +24,7 @@ import org.apache.sling.hamcrest.matchers.ResourceIteratorPathMatcher;
 import org.hamcrest.Matcher;
 
 /**
- * A collection of <tt>Matcher</tt>s for resource iterators.
+ * A collection of {@code Matcher}s for resource iterators.
  */
 public final class ResourceIteratorMatchers {
     

--- a/src/main/java/org/apache/sling/hamcrest/ResourceMatchers.java
+++ b/src/main/java/org/apache/sling/hamcrest/ResourceMatchers.java
@@ -30,15 +30,15 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
 /**
- * A collection of <tt>Matcher</tt>s that work on the Resource API level
+ * A collection of {@code Matcher}s that work on the Resource API level
  *
  */
 public final class ResourceMatchers {
     
     /**
-     * Matches resources which have amongst their children the specified <tt>children</tt>.
+     * Matches resources which have amongst their children the specified {@code children}.
      * 
-     * Child resources not contained in the specified <tt>children</tt> are not validated. The order of the children does not matter.
+     * Child resources not contained in the specified {@code children} are not validated. The order of the children does not matter.
      * 
      * <pre>
      * assertThat(resource, hasChildren('child1', 'child2'));
@@ -52,7 +52,7 @@ public final class ResourceMatchers {
     }
     
     /**
-     * Matches resources which have exactly the children with the names given in <tt>children</tt>. The order is validated as well.
+     * Matches resources which have exactly the children with the names given in {@code children}. The order is validated as well.
      * 
      * <pre>
      * assertThat(resource, containsChildren('child1', 'child2'));
@@ -67,7 +67,7 @@ public final class ResourceMatchers {
     
     
     /**
-     * Matches resources which have exactly the children with the names given in <tt>children</tt>. The order is not validated.
+     * Matches resources which have exactly the children with the names given in {@code children}. The order is not validated.
      * 
      * <pre>
      * assertThat(resource, containsChildrenInAnyOrder('child1', 'child2'));
@@ -109,7 +109,7 @@ public final class ResourceMatchers {
     }
 
     /**
-     * Matches resources with a resource type set to the specified <tt>resourceType</tt>
+     * Matches resources with a resource type set to the specified {@code resourceType}
      * 
      * <pre>
      * assertThat(resource, resourceOfType('my/app'));
@@ -122,9 +122,9 @@ public final class ResourceMatchers {
     }
 
     /**
-     * Matches resources which has at least the specified <tt>properties</tt> defined with matching values
+     * Matches resources which has at least the specified {@code properties} defined with matching values
      * 
-     * <p>Values not declared in the the <tt>properties</tt> parameter are not validated.</p>
+     * <p>Values not declared in the the {@code properties} parameter are not validated.</p>
      * <pre>
      * Map&lt;String, Object&gt; expectedProperties = new HashMap&lt;&gt;();
      * expectedProperties.put("jcr:title", "Node title");
@@ -141,9 +141,9 @@ public final class ResourceMatchers {
     }
 
     /**
-     * Matches resources which has at least the specified <tt>properties</tt> defined with matching values
+     * Matches resources which has at least the specified {@code properties} defined with matching values
      * 
-     * <p>Values not declared in the the <tt>properties</tt> parameter are not validated.</p>
+     * <p>Values not declared in the the {@code properties} parameter are not validated.</p>
      * <pre>
      * Map&lt;String, Object&gt; expectedProperties = new HashMap&lt;&gt;();
      * expectedProperties.put("jcr:title", "Node title");
@@ -160,9 +160,9 @@ public final class ResourceMatchers {
     }
 
     /**
-     * Matches resources which has the given name and at least the specified <tt>properties</tt> defined with matching values
+     * Matches resources which has the given name and at least the specified {@code properties} defined with matching values
      * 
-     * <p>Values not declared in the the <tt>properties</tt> parameter are not validated.</p>
+     * <p>Values not declared in the the {@code properties} parameter are not validated.</p>
      * <pre>
      * Map&lt;String, Object&gt; expectedProperties = new HashMap&lt;&gt;();
      * expectedProperties.put("jcr:title", "Node title");
@@ -180,9 +180,9 @@ public final class ResourceMatchers {
     }
 
     /**
-     * Matches resources which has the given name and at least the specified <tt>properties</tt> defined with matching values
+     * Matches resources which has the given name and at least the specified {@code properties} defined with matching values
      * 
-     * <p>Values not declared in the the <tt>properties</tt> parameter are not validated.</p>
+     * <p>Values not declared in the the {@code properties} parameter are not validated.</p>
      * <pre>
      * Map&lt;String, Object&gt; expectedProperties = new HashMap&lt;&gt;();
      * expectedProperties.put("jcr:title", "Node title");

--- a/src/main/java/org/apache/sling/hamcrest/matchers/ResourceChildrenMatcher.java
+++ b/src/main/java/org/apache/sling/hamcrest/matchers/ResourceChildrenMatcher.java
@@ -56,7 +56,7 @@ public class ResourceChildrenMatcher extends TypeSafeMatcher<Resource> {
                 this.iterarableMatcher = org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder(resourceMatchers);
             }
         } else {
-            this.iterarableMatcher = org.hamcrest.core.IsCollectionContaining.hasItems(resourceMatchers.toArray(new ResourceNameMatcher[0]));
+            this.iterarableMatcher = org.hamcrest.core.IsIterableContaining.hasItems(resourceMatchers.toArray(new ResourceNameMatcher[0]));
         }
     }
 

--- a/src/test/java/org/apache/sling/hamcrest/MapUtilTest.java
+++ b/src/test/java/org/apache/sling/hamcrest/MapUtilTest.java
@@ -20,6 +20,7 @@ package org.apache.sling.hamcrest;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Test;
@@ -28,11 +29,44 @@ import com.google.common.collect.ImmutableMap;
 
 public class MapUtilTest {
 
-    @Test
+    private static final ImmutableMap<String, Object> EXPECTED_MAP = ImmutableMap.<String, Object>of("param1", "var1", "param2", 123, "param3", true);
+
+	@Test
     public void testMapObjectVarargs() {
         Map<String, Object> convertedMap = MapUtil.toMap("param1", "var1", "param2", 123, "param3", true);
         
-        assertEquals(ImmutableMap.<String, Object>of("param1", "var1", "param2", 123, "param3", true), convertedMap);
+        assertEquals(EXPECTED_MAP, convertedMap);
     }
-    
+ 
+    @Test
+    public void testMapObjectMap() {
+        Map<String, Object> convertedMap = MapUtil.toMap(EXPECTED_MAP);
+        
+        assertEquals(EXPECTED_MAP, convertedMap);
+    }
+ 
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMapObjectVarArgs_NotMap() {
+        MapUtil.toMap("param1", "var1", "param2", 123, "param3");
+    }
+ 
+    @Test
+    public void testMapObjectVarargs_EmptyArgs() {
+        Map<String, Object> convertedMap = MapUtil.toMap();
+        
+        assertEquals(Collections.emptyMap(), convertedMap);
+    }
+ 
+    @Test
+    public void testMapObjectVarargs_Null() {
+        Map<String, Object> convertedMap = MapUtil.toMap((Object[])null);
+        
+        assertEquals(Collections.emptyMap(), convertedMap);
+    }
+ 
+    @Test(expected = IllegalArgumentException.class)
+    public void testMapObjectVarArgs_OddNumberOfArgs() {
+        MapUtil.toMap("param1", "var1", "param2", 123, "param3");
+    }
 }

--- a/src/test/java/org/apache/sling/hamcrest/ResourceCollectionMatchersTest.java
+++ b/src/test/java/org/apache/sling/hamcrest/ResourceCollectionMatchersTest.java
@@ -19,7 +19,7 @@
 package org.apache.sling.hamcrest;
 
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 

--- a/src/test/java/org/apache/sling/hamcrest/ResourceIteratorMatchersTest.java
+++ b/src/test/java/org/apache/sling/hamcrest/ResourceIteratorMatchersTest.java
@@ -19,7 +19,7 @@
 package org.apache.sling.hamcrest;
 
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 

--- a/src/test/java/org/apache/sling/hamcrest/ResourceMatchersTest.java
+++ b/src/test/java/org/apache/sling/hamcrest/ResourceMatchersTest.java
@@ -16,13 +16,15 @@
  */
 package org.apache.sling.hamcrest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.util.Map;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
+
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -40,8 +42,8 @@ public class ResourceMatchersTest {
                 "some other key", "some other value");
         
         Resource resource = context.resourceResolver().getResource("/resource");
-        Assert.assertThat(resource, ResourceMatchers.resourceType("some/type"));
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.resourceType("some/other/type")));
+        assertThat(resource, ResourceMatchers.resourceType("some/type"));
+        assertThat(resource, Matchers.not(ResourceMatchers.resourceType("some/other/type")));
     }
 
     @Test
@@ -49,8 +51,8 @@ public class ResourceMatchersTest {
         context.build().resource("/resource");
         
         Resource resource = context.resourceResolver().getResource("/resource");
-        Assert.assertThat(resource, ResourceMatchers.path("/resource"));
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.path("some/other/name")));
+        assertThat(resource, ResourceMatchers.path("/resource"));
+        assertThat(resource, Matchers.not(ResourceMatchers.path("some/other/name")));
     }
 
     @Test
@@ -58,8 +60,8 @@ public class ResourceMatchersTest {
         context.build().resource("/resource");
         
         Resource resource = context.resourceResolver().getResource("/resource");
-        Assert.assertThat(resource, ResourceMatchers.name("resource"));
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.name("some/other/name")));
+        assertThat(resource, ResourceMatchers.name("resource"));
+        assertThat(resource, Matchers.not(ResourceMatchers.name("some/other/name")));
     }
 
     @Test
@@ -77,20 +79,20 @@ public class ResourceMatchersTest {
                 .build();
         
         Resource resource = context.resourceResolver().getResource("/resource");
-        Assert.assertThat(resource, ResourceMatchers.props(expectedProperties));
+        assertThat(resource, ResourceMatchers.props(expectedProperties));
         
         // test existing key with not matching value
         expectedProperties = ImmutableMap.<String, Object>builder()
                 .put("key1", "value1")
                 .put("key3", "value3")
                 .build();
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
         
         // test non-existing key
         expectedProperties = ImmutableMap.<String, Object>builder()
                 .put("key5", "value5")
                 .build();
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
     }
 
     @Test
@@ -108,38 +110,38 @@ public class ResourceMatchersTest {
         };
         
         Resource resource = context.resourceResolver().getResource("/resource");
-        Assert.assertThat(resource, ResourceMatchers.props(expectedProperties));
+        assertThat(resource, ResourceMatchers.props(expectedProperties));
 
         // test existing key with not matching value
         expectedProperties = new Object[] {
                 "key1", "value1",
                 "key3", new int[] { 1, 2, 5 }
         };
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
 
         expectedProperties = new Object[] {
                 "key1", "value1",
                 "key3", new int[] { 1, 2 }
         };
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
         
         expectedProperties = new Object[] {
                 "key1", "value1",
                 "key3", 1
         };
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
         
         expectedProperties = new Object[] {
                 "key1", "value1",
                 "key3", null
         };
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
         
         // test non-existing key
         expectedProperties = new Object[] {
                 "key5", "value5"
         };
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.props(expectedProperties)));
     }
 
     @Test
@@ -149,7 +151,7 @@ public class ResourceMatchersTest {
             .resource("/parent/child2");
         
         Resource resource = context.resourceResolver().getResource("/parent");
-        Assert.assertThat(resource, ResourceMatchers.hasChildren("child1"));
+        assertThat(resource, ResourceMatchers.hasChildren("child1"));
     }
     
     @Test
@@ -165,17 +167,17 @@ public class ResourceMatchersTest {
                 .build();
         
         Resource resource = context.resourceResolver().getResource("/resource");
-        Assert.assertThat(resource, ResourceMatchers.nameAndProps("resource", expectedProperties));
+        assertThat(resource, ResourceMatchers.nameAndProps("resource", expectedProperties));
         
         // test not matching name
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.nameAndProps("resource1", expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.nameAndProps("resource1", expectedProperties)));
         
         // test existing key with not matching value
         expectedProperties = ImmutableMap.<String, Object>builder()
                 .put("key1", "value1")
                 .put("key2", "value3")
                 .build();
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.nameAndProps("resource", expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.nameAndProps("resource", expectedProperties)));
     }
 
     @Test
@@ -191,17 +193,17 @@ public class ResourceMatchersTest {
         };
         
         Resource resource = context.resourceResolver().getResource("/resource");
-        Assert.assertThat(resource, ResourceMatchers.nameAndProps("resource", expectedProperties));
+        assertThat(resource, ResourceMatchers.nameAndProps("resource", expectedProperties));
         
         // test not matching name
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.nameAndProps("resource1", expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.nameAndProps("resource1", expectedProperties)));
         
         // test existing key with not matching value
         expectedProperties = new Object[] {
                 "key1", "value1",
                 "key2", "value3"
         };
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.nameAndProps("resource", expectedProperties)));
+        assertThat(resource, Matchers.not(ResourceMatchers.nameAndProps("resource", expectedProperties)));
     }
 
     @Test
@@ -211,9 +213,9 @@ public class ResourceMatchersTest {
             .resource("/parent/child2");
         
         Resource resource = context.resourceResolver().getResource("/parent");
-        Assert.assertThat(resource, ResourceMatchers.containsChildrenInAnyOrder("child2", "child1"));
-        Assert.assertThat(resource, ResourceMatchers.containsChildrenInAnyOrder("child1", "child2"));
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.containsChildren("child2", "child3", "child1")));
+        assertThat(resource, ResourceMatchers.containsChildrenInAnyOrder("child2", "child1"));
+        assertThat(resource, ResourceMatchers.containsChildrenInAnyOrder("child1", "child2"));
+        assertThat(resource, Matchers.not(ResourceMatchers.containsChildren("child2", "child3", "child1")));
     }
 
     @Test
@@ -223,9 +225,9 @@ public class ResourceMatchersTest {
             .resource("/parent/child2");
         
         Resource resource = context.resourceResolver().getResource("/parent");
-        Assert.assertThat(resource, ResourceMatchers.containsChildren("child1", "child2"));
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.containsChildren("child2", "child1")));
-        Assert.assertThat(resource, Matchers.not(ResourceMatchers.containsChildren("child1", "child2", "child3")));
+        assertThat(resource, ResourceMatchers.containsChildren("child1", "child2"));
+        assertThat(resource, Matchers.not(ResourceMatchers.containsChildren("child2", "child1")));
+        assertThat(resource, Matchers.not(ResourceMatchers.containsChildren("child1", "child2", "child3")));
     }
 
 }


### PR DESCRIPTION
Moved assertThat in tests over to Hamcrest's assertThat. Moved from deprecated IsCollectionContaining to IsIterableContaining in MapUtil.  Addressed some type warnings by adding types to untyped generics.