### PR TITLE
SLING-12139 - Bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.4.0</version>
+            <version>2.22.0</version>
             <scope>provided</scope>
         </dependency>
         

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock</artifactId>
-            <version>1.8.0</version>
+            <version>3.4.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
-        <version>47</version>
+        <version>52</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
org.apache.sling.testing.sling-mock 1.8.0->3.4.14
org.apache.sling:sling 47->52
org.apache.sling.api 2.4.0->2,22.0