### PR TITLE
SLING-12831 fix resource type matching for special resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.testing.hamcrest</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>Apache Sling Testing Hamcrest</name>
     <description>Hamcrest matchers tailored for Apache Sling</description>

--- a/src/main/java/org/apache/sling/hamcrest/ResourceMatchers.java
+++ b/src/main/java/org/apache/sling/hamcrest/ResourceMatchers.java
@@ -17,15 +17,14 @@
 package org.apache.sling.hamcrest;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.hamcrest.matchers.ResourceChildrenMatcher;
 import org.apache.sling.hamcrest.matchers.ResourceNameMatcher;
 import org.apache.sling.hamcrest.matchers.ResourcePathMatcher;
 import org.apache.sling.hamcrest.matchers.ResourcePropertiesMatcher;
+import org.apache.sling.hamcrest.matchers.ResourceTypeMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
@@ -109,16 +108,34 @@ public final class ResourceMatchers {
     }
 
     /**
-     * Matches resources with a resource type set to the specified {@code resourceType}
+     * Matches resources with a resource type set to the specified {@code resourceType} (exactly).
+     * In order to check for resource types allowing more specific ones use {@link #resourceTypeOrDerived(String)}.
      * 
      * <pre>
-     * assertThat(resource, resourceOfType('my/app'));
+     * assertThat(resource, resourceType('my/app'));
      * </pre>
      * @param resourceType the resource type to match
      * @return a matcher instance
      */
     public static Matcher<Resource> resourceType(String resourceType) {
-        return new ResourcePropertiesMatcher(Collections.<String, Object> singletonMap(ResourceResolver.PROPERTY_RESOURCE_TYPE, resourceType));
+        return new ResourceTypeMatcher(resourceType, false);
+    }
+
+    /**
+     * Matches resources with a resource type set to the specified {@code resourceType} or one of its sub types.
+     * In order to check for exact resource types only use {@link #resourceType(String)}.
+     * 
+     * <pre>
+     * assertThat(resource, resourceTypeOrDerived('my/app'));
+     * </pre>
+     * @param resourceType the resource type to match
+     * @return a matcher instance
+     * @since 1.1.0
+     * @see Resource#isResourceType(String)
+     * @see #resourceType(String)
+     */
+    public static Matcher<Resource> resourceTypeOrDerived(String resourceType) {
+        return new ResourceTypeMatcher(resourceType, true);
     }
 
     /**

--- a/src/main/java/org/apache/sling/hamcrest/matchers/ResourcePropertiesMatcher.java
+++ b/src/main/java/org/apache/sling/hamcrest/matchers/ResourcePropertiesMatcher.java
@@ -46,7 +46,7 @@ public class ResourcePropertiesMatcher extends TypeSafeMatcher<Resource> {
 
     @Override
     protected boolean matchesSafely(Resource item) {
-        ValueMap givenProps = item.adaptTo(ValueMap.class);
+        ValueMap givenProps = item.getValueMap();
         for (Map.Entry<String, Object> prop : expectedProps.entrySet()) {
             Object givenValue = givenProps.get(prop.getKey());
             Object expectedValue = prop.getValue();
@@ -93,11 +93,7 @@ public class ResourcePropertiesMatcher extends TypeSafeMatcher<Resource> {
 
     @Override
     protected void describeMismatchSafely(Resource item, Description mismatchDescription) {
-        Map<String, Object> actualProperties = item.adaptTo(ValueMap.class);
-        if (actualProperties == null) {
-            mismatchDescription.appendText("was Resource which does not expose a value map via adaptTo(ValueMap.class)");
-            return;
-        }
+        Map<String, Object> actualProperties = item.getValueMap();
         mismatchDescription.appendText("was Resource with properties ")
              .appendValueList("[", ",", "]", convertArraysToStrings(actualProperties).entrySet())
              .appendText(" (resource: ")

--- a/src/main/java/org/apache/sling/hamcrest/matchers/ResourceTypeMatcher.java
+++ b/src/main/java/org/apache/sling/hamcrest/matchers/ResourceTypeMatcher.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.hamcrest.matchers;
+
+import org.apache.sling.api.resource.Resource;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher which matches whenever the type of the given resource is equal to the type in the constructor (optionally allowing also sub types).
+ */
+public class ResourceTypeMatcher extends TypeSafeMatcher<Resource> {
+
+    private final String type;
+    private final boolean allowSubtypes;
+
+    public ResourceTypeMatcher(String type, boolean allowSubtypes) {
+        this.type = type;
+        this.allowSubtypes = allowSubtypes;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Resource with type ").appendValue(type);
+    }
+
+    @Override
+    protected boolean matchesSafely(Resource resource) {
+        if (allowSubtypes) {
+            return resource.isResourceType(type);
+        } else {
+            return type.equals(resource.getResourceType());
+        }
+    }
+
+    @Override
+    protected void describeMismatchSafely(Resource resource, Description mismatchDescription) {
+        mismatchDescription.appendText("was Resource with type ").appendValue(resource.getResourceType()).appendText(" (resource: ").appendValue(resource).appendText(")");
+    }
+
+}


### PR DESCRIPTION
Not all resources expose their resource type via properties yet (SLING-12781). Therefore use dedicated methods instead of checking properties.